### PR TITLE
Test files should be placed as near as possible

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "build": "npm-run-all prebuild build:typescript",
     "watch": "tsc --watch",
     "pretest": "npm run build",
-    "test": "mocha --opts mocha.opts dist/tests",
+    "test": "mocha --opts mocha.opts './dist/**/*.test.js'",
     "lint": "tslint src/**/*.ts"
   },
   "bin": {

--- a/src/ast_diff.test.ts
+++ b/src/ast_diff.test.ts
@@ -1,6 +1,6 @@
 import * as assert from "assert";
 import * as css from "css";
-import {astDiff} from "../ast_diff";
+import {astDiff} from "./ast_diff";
 
 describe("astDiff", () => {
   it("should return result that represents 'no changed' when there are no changed between 2 StyleSheets", () => {

--- a/src/collection_utils.test.ts
+++ b/src/collection_utils.test.ts
@@ -1,5 +1,5 @@
 import * as assert from "assert";
-import {OrderedStringSet} from "../collection_utils";
+import {OrderedStringSet} from "./collection_utils";
 
 describe("OrderedStringSet", () => {
   describe("#union", () => {

--- a/src/console_document.test.ts
+++ b/src/console_document.test.ts
@@ -1,5 +1,5 @@
 import * as assert from "assert";
-import {ConsoleDocument} from "../format/console_document";
+import {ConsoleDocument} from "./format/console_document";
 
 
 describe("ConsoleDocument", () => {

--- a/src/css_utils.test.ts
+++ b/src/css_utils.test.ts
@@ -1,7 +1,7 @@
 import * as assert from "assert";
 import * as css from "css";
-import {NodeSet} from "../css_utils";
-import {NoRulesError} from "../error";
+import {NodeSet} from "./css_utils";
+import {NoRulesError} from "./error";
 
 describe("NodeSet", () => {
   describe("#constructor", () => {

--- a/src/order_diff.test.ts
+++ b/src/order_diff.test.ts
@@ -1,7 +1,7 @@
 import * as assert from "assert";
 import * as css from "css";
-import {orderDiff, OrderDiffResult} from "../order_diff";
-import {keys} from "../collection_utils";
+import {orderDiff, OrderDiffResult} from "./order_diff";
+import {keys} from "./collection_utils";
 
 describe("orderDiff", () => {
   it("should return empty result when no differences exist between specified 2 StyleSheets", () => {


### PR DESCRIPTION
We can understand what files are not tested.
Because test files are listed the next of its target.
